### PR TITLE
fix error[E0554]: `#![feature]` may not be used on the stable release…

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(file_create_new)]
-
 use reqwest;
 use html2text::from_read;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
… channel

error[E0554]: `#![feature]` may not be used on the stable release channel
 --> src/main.rs:1:12
  |
1 | #![feature(file_create_new)]
  |            ^^^^^^^^^^^^^^^

Seems like this line is no longer needed and can be safely removed?